### PR TITLE
Metadata for Global Warming Potentials

### DIFF
--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -136,6 +136,13 @@
             "object": "metadata",
             "comment": "review metadata"
         }
+		{
+            "title": "Jonas Huber",
+            "email": "jonas.huber@rl-institut.de",
+            "date": "2019-10-08",
+            "object": "metadata",
+            "comment": "review metadata"
+        }
     ],
     "resources": [
         {

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -143,37 +143,37 @@
                         "name": "id",
                         "description": "unique identifier",
                         "type": "serial",
-                        "unit": "null"
+                        "unit": null
                     },
                     {
                         "name": "greenhouse_gas",
                         "description": "Name of the greenhouse gas given as common name, chemical name and/or industrial abbreviation",
                         "type": "varchar",
-                        "unit": "null"
+                        "unit": null
                     },
                     {
                         "name": "gas_group",
                         "description": "Gas group as mentioned in the respective IPCC Assessment Report. Attention: The gas groups are not harmonized across the various IPCC Assessment Reports!",
                         "type": "varchar",
-                        "unit": "null"
+                        "unit": null
                     },
                     {
                         "name": "chemical_formula",
                         "description": "Chemical formula of the respective greenhouse gas",
                         "type": "varchar",
-                        "unit": "null"
+                        "unit": null
                     },
                     {
                         "name": "ipcc_report",
                         "description": "Source of the GWP value. AR1 meaning the First Assessment Report, AR2 the second Assessment Report etc.",
                         "type": "varchar",
-                        "unit": "null"
+                        "unit": null
                     },
                     {
                         "name": "source",
                         "description": "Source table within the respective IPCC Assessment Report",
                         "type": "varchar",
-                        "unit": "null"
+                        "unit": null
                     },
                     {
                         "name": "time_horizon",
@@ -185,13 +185,13 @@
                         "name": "global_warming_potential",
                         "description": "Global warming potential of a greenhouse gas",
                         "type": "float",
-                        "unit": "null"
+                        "unit": null
                     },
                     {
                         "name": "inequality_sign",
                         "description": "For some gases the Assessment Reports can only give lower or upper limits of the GWP values. In this case this column provides information whether the GWP is below or above a specific value.",
                         "type": "varchar",
-                        "unit": "null"
+                        "unit": null
                     }
                 ],
                 "primaryKey": [

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -221,7 +221,7 @@
         }
     ],
     "review": {
-        "path": null,
+        "path": "https://github.com/OpenEnergyPlatform/data-preprocessing/issues/40",
         "badge": null
     },
     "metaMetadata": {

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -221,7 +221,7 @@
         }
     ],
     "review": {
-        "path": "https://github.com/OpenEnergyPlatform/data-preprocessing/issues/40",
+        "path": null,
         "badge": null
     },
     "metaMetadata": {

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -13,34 +13,89 @@
         "Greenhouse gas"
     ],
     "publicationDate": "2019-09-09",
-    "spatial": {
-        "extent": "global"
+    "context": {
+        "homepage": null,
+        "documentation": null,
+        "sourceCode": null,
+        "contact": null,
+        "grantNo": null,
+        "fundingAgency": null,
+        "fundingAgencyLogo": null,
+        "publisherLogo": null
     },
+    "spatial": {
+        "location": null,
+        "extent": "global",
+        "resolution": null
+    },
+    "temporal": {
+        "referenceDate": null,
+        "timeseries":
+            {"start": null,
+            "end": null,
+            "resolution": null,
+            "alignment": null,
+            "aggregationType": null },
     "sources": [
         {
             "title": "Climate Change: The IPCC Scientific Assessment",
             "description": "Report Prepared for IPCC by Working Group 1",
-            "path": "https://www.ipcc.ch/report/ar1/wg1/"
+            "path": "https://www.ipcc.ch/report/ar1/wg1/",
+            "licenses": [
+                {"name": null,
+                "title": null,
+                "path": null,
+                "instruction": null,
+                "attribution": null}],
+            "copyright": null
         },
         {
             "title": "Climate Change 1995: The Science of Climate Change",
             "description": "Contribution of Working Group I to the Second Assessment Report of the Intergovernmental Panel on Climate Change",
-            "path": "https://www.ipcc.ch/report/ar2/wg1/"
+            "path": "https://www.ipcc.ch/report/ar2/wg1/",
+            "licenses": [
+                {"name": null,
+                "title": null,
+                "path": null,
+                "instruction": null,
+                "attribution": null}],
+            "copyright": null
         },
         {
             "title": "Climate Change 2001: The Scientific Basis",
             "description": "Contribution of Working Group I to the Third Assessment Report of the Intergovernmental Panel on Climate Change",
-            "path": "https://www.ipcc.ch/report/ar3/wg1/"
+            "path": "https://www.ipcc.ch/report/ar3/wg1/",
+            "licenses": [
+                {"name": null,
+                "title": null,
+                "path": null,
+                "instruction": null,
+                "attribution": null}],
+            "copyright": null
         },
         {
             "title": "Climate Change 2007: The Physical Science Basis",
             "description": "Working Group I Contribution to the Fourth Assessment Report of the Intergovernmental Panel on Climate Change",
-            "path": "https://www.ipcc.ch/report/ar4/wg1/"
+            "path": "https://www.ipcc.ch/report/ar4/wg1/",
+            "licenses": [
+                {"name": null,
+                "title": null,
+                "path": null,
+                "instruction": null,
+                "attribution": null}],
+            "copyright": null
         },
         {
             "title": "Climate Change 2013: The Physical Science Basis",
             "description": "Working Group I Contribution to the Fifth Assessment Report of the Intergovernmental Panel on Climate Change",
-            "path": "https://www.ipcc.ch/report/ar5/wg1/"
+            "path": "https://www.ipcc.ch/report/ar5/wg1/",
+            "licenses": [
+                {"name": null,
+                "title": null,
+                "path": null,
+                "instruction": null,
+                "attribution": null}],
+            "copyright": null
         }
     ],
     "license": [
@@ -141,6 +196,15 @@
                 ],
                 "primaryKey": [
                     "id"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [],
+                        "reference": {
+                            "resource": null,
+                            "fields": []
+                        }
+                    }
                 ]
             },
             "dialect": {
@@ -149,6 +213,10 @@
             }
         }
     ],
+    "review": {
+        "path": null,
+        "badge": null
+    },
     "metaMetadata": {
         "metadataVersion": "OEP-1.4.0",
         "metadataLicense": {

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -57,14 +57,14 @@
             "title": "Lukas Emele",
             "email": "oedb@oeko.de",
             "date": "2019-09-09",
-            "object": "",
+            "object": null,
             "comment": "Collection of data from IPCC assessment reports"
         },
         {
             "title": "Lukas Emele",
             "email": "oedb@oeko.de",
             "date": "2019-09-09",
-            "object": "",
+            "object": null,
             "comment": "Creation of metadata"
         }
     ],
@@ -137,7 +137,7 @@
                 ]
             },
             "dialect": {
-                "delimiter": "",
+                "delimiter": null,
                 "decimalSeparator": "."
             }
         }

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -1,0 +1,162 @@
+{
+    "name": "szenariendb_gwp",
+    "title": "Global warming potentials from IPCC Assessment Reports",
+    "id": "https://openenergy-platform.org/dataedit/view/model_draft/szenariendb_gwp",
+    "description": "This table holds global warming potentials (GWP) published in the IPCC Assessment reports. Due to legal aspects this table currently only holds a subset gases of all published GWPs. The subset was chosen to the gases most related to energy modeling.",
+    "language": [
+        "english"
+    ],
+    "keywords": [
+        "IPCC",
+        "Global warming potential",
+        "GWP",
+        "Greenhouse gas"
+    ],
+    "publicationDate": "2019-09-09",
+    "spacial": {
+        "extent": "global"
+    },
+    "sources": [
+        {
+            "title": "Climate Change: The IPCC Scientific Assessment",
+            "description": "Report Prepared for IPCC by Working Group 1",
+            "path": "https://www.ipcc.ch/report/ar1/wg1/"
+        },
+        {
+            "title": "Climate Change 1995: The Science of Climate Change",
+            "description": "Contribution of Working Group I to the Second Assessment Report of the Intergovernmental Panel on Climate Change",
+            "path": "https://www.ipcc.ch/report/ar2/wg1/"
+        },
+        {
+            "title": "Climate Change 2001: The Scientific Basis",
+            "description": "Contribution of Working Group I to the Third Assessment Report of the Intergovernmental Panel on Climate Change",
+            "path": "https://www.ipcc.ch/report/ar3/wg1/"
+        },
+        {
+            "title": "Climate Change 2007: The Physical Science Basis",
+            "description": "Working Group I Contribution to the Fourth Assessment Report of the Intergovernmental Panel on Climate Change",
+            "path": "https://www.ipcc.ch/report/ar4/wg1/"
+        },
+        {
+            "title": "Climate Change 2013: The Physical Science Basis",
+            "description": "Working Group I Contribution to the Fifth Assessment Report of the Intergovernmental Panel on Climate Change",
+            "path": "https://www.ipcc.ch/report/ar5/wg1/"
+        }
+    ],
+    "license": [
+        {
+            "name": "dl-de-by-2.0",
+            "title": "Data licence Germany \u2013 attribution \u2013 version 2.0",
+            "path": "https://www.govdata.de/dl-de/by-2-0",
+            "instruction": "https://www.govdata.de/dl-de/by-2-0",
+            "attribution": "\u00a9 \u00d6ko-Institut"
+        }
+    ],
+    "contributors": [
+        {
+            "title": "Lukas Emele",
+            "email": "oedb@oeko.de",
+            "date": "2019-09-09",
+            "object": "",
+            "comment": "Collection of data from IPCC assessment reports"
+        },
+        {
+            "title": "Lukas Emele",
+            "email": "oedb@oeko.de",
+            "date": "2019-09-09",
+            "object": "",
+            "comment": "Creation of metadata"
+        }
+    ],
+    "resources": [
+        {
+            "profile": "tabular-data-resource",
+            "name": "climate.szenariendb_gwp",
+            "path": "https://openenergy-platform.org/dataedit/view/model_draft/szenariendb_gwp",
+            "format": "PostgreSQL",
+            "encoding": "UTF-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "unique identifier",
+                        "type": "serial",
+                        "unit": "null"
+                    },
+                    {
+                        "name": "greenhouse_gas",
+                        "description": "Name of the greenhouse gas given as common name, chemical name and/or industrial abbreviation",
+                        "type": "varchar",
+                        "unit": "null"
+                    },
+                    {
+                        "name": "gas_group",
+                        "description": "Gas group as mentioned in the respective IPCC Assessment Report. Attention: The gas groups are not harmonized across the various IPCC Assessment Reports!",
+                        "type": "varchar",
+                        "unit": "null"
+                    },
+                    {
+                        "name": "chemical_formula",
+                        "description": "Chemical formula of the respective greenhouse gas",
+                        "type": "varchar",
+                        "unit": "null"
+                    },
+                    {
+                        "name": "ipcc_report",
+                        "description": "Source of the GWP value. AR1 meaning the First Assessment Report, AR2 the second Assessment Report etc.",
+                        "type": "varchar",
+                        "unit": "null"
+                    },
+                    {
+                        "name": "source",
+                        "description": "Source table within the respective IPCC Assessment Report",
+                        "type": "varchar",
+                        "unit": "null"
+                    },
+                    {
+                        "name": "time_horizon",
+                        "description": "Time horizon for which the GWP of a greenhouse gas was calculated. If unsure: a time horizon of 100 years is most commonly used.",
+                        "type": "integer",
+                        "unit": "year"
+                    },
+                    {
+                        "name": "global_warming_potential",
+                        "description": "Global warming potential of a greenhouse gas",
+                        "type": "float",
+                        "unit": "null"
+                    },
+                    {
+                        "name": "inequality_sign",
+                        "description": "For some gases the Assessment Reports can only give lower or upper limits of the GWP values. In this case this column provides information whether the GWP is below or above a specific value.",
+                        "type": "varchar",
+                        "unit": "null"
+                    }
+                ],
+                "primaryKey": [
+                    "id"
+                ]
+            },
+            "dialect": {
+                "delimiter": "",
+                "decimalSeparator": "."
+            }
+        }
+    ],
+    "metaMetadata": {
+        "metadataVersion": "OEP-1.4.0",
+        "metadataLicense": {
+            "name": "CC0-1.0",
+            "title": "Creative Commons Zero v1.0 Universal",
+            "path": "https://creativecommons.org/publicdomain/zero/1.0/"
+        }
+    },
+    "_comment": {
+        "metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
+        "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss\u00b1hh)",
+        "units": "Use a space between numbers and units (100 m)",
+        "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
+        "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
+        "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
+        "null": "If not applicable use (null)"
+    }
+}

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -98,7 +98,7 @@
             "copyright": null
         }
     ],
-    "license": [
+    "licenses": [
         {
             "name": "dl-de-by-2.0",
             "title": "Data licence Germany \u2013 attribution \u2013 version 2.0",

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -66,6 +66,13 @@
             "date": "2019-09-09",
             "object": null,
             "comment": "Creation of metadata"
+        },
+                {
+            "title": "Mirjam Stappel",
+            "email": "mirjam.stappel@iee.fraunhofer.de",
+            "date": "2019-10-04",
+            "object": "metadata",
+            "comment": "review metadata"
         }
     ],
     "resources": [

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -4,7 +4,7 @@
     "id": "https://openenergy-platform.org/dataedit/view/model_draft/szenariendb_gwp",
     "description": "This table holds global warming potentials (GWP) published in the IPCC Assessment reports. Due to legal aspects this table currently only holds a subset gases of all published GWPs. The subset was chosen to the gases most related to energy modeling.",
     "language": [
-        "english"
+        "en-GB"
     ],
     "keywords": [
         "IPCC",

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -112,14 +112,14 @@
             "title": "Lukas Emele",
             "email": "oedb@oeko.de",
             "date": "2019-09-09",
-            "object": null,
+            "object": "data",
             "comment": "Collection of data from IPCC assessment reports"
         },
         {
             "title": "Lukas Emele",
             "email": "oedb@oeko.de",
             "date": "2019-09-09",
-            "object": null,
+            "object": "metadata",
             "comment": "Creation of metadata"
         },
                 {

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -13,7 +13,7 @@
         "Greenhouse gas"
     ],
     "publicationDate": "2019-09-09",
-    "spacial": {
+    "spatial": {
         "extent": "global"
     },
     "sources": [

--- a/data-review/climate.szenariendb_gwp.json
+++ b/data-review/climate.szenariendb_gwp.json
@@ -122,10 +122,17 @@
             "object": "metadata",
             "comment": "Creation of metadata"
         },
-                {
+        {
             "title": "Mirjam Stappel",
             "email": "mirjam.stappel@iee.fraunhofer.de",
             "date": "2019-10-04",
+            "object": "metadata",
+            "comment": "review metadata"
+        },
+        {
+            "title": "Christian Hofmann",
+            "email": "christian.hofmann@rl-institut.de",
+            "date": "2019-10-08",
             "object": "metadata",
             "comment": "review metadata"
         }


### PR DESCRIPTION
Closes #40 

Metadata for Global Warming Potential values in this table:
* https://openenergy-platform.org/dataedit/view/model_draft/szenariendb_gwp

Target schema is: **climate.szenariendb_gwp**.

The metadata is in the file https://github.com/OpenEnergyPlatform/data-preprocessing/blob/review/SzenarienDB_GWP/data-review/climate.szenariendb_gwp.json on the branch **review/SzenarienDB_GWP**